### PR TITLE
Support Linux in the ./build script

### DIFF
--- a/build
+++ b/build
@@ -12,5 +12,5 @@ swift build
 popd
 
 echo Copying to ${INSTALL_PATH}
-cp ${BUILD_PATH}/*.dylib  ${INSTALL_PATH}
+cp ${BUILD_PATH}/*.{dylib,so} ${INSTALL_PATH} 2>/dev/null || true
 

--- a/build
+++ b/build
@@ -6,7 +6,7 @@ BUILD_PATH=poietic-godot/.build/debug
 
 git submodule update --init --recursive
 
-pushd $(pwd) > /dev/null
+pushd "$(pwd)" > /dev/null
 cd poietic-godot
 swift build
 popd

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 INSTALL_PATH=bin


### PR DESCRIPTION
* Support Linux build artifacts by copying `.so` files too in `./build` script
* explicitly using `/bin/bash` adds support for already used `popd` and `pushd` commands (`/bin/sh` fails in linux)
* quoting $(pwd) expansion prevents problems with working directory having spaces
